### PR TITLE
Add 2023 version: 1.4.0, switch to current JRE

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -30,10 +30,26 @@
         "type": "indirect"
       }
     },
+    "nixos2405": {
+      "locked": {
+        "lastModified": 1730137625,
+        "narHash": "sha256-9z8oOgFZiaguj+bbi3k4QhAD6JabWrnv7fscC/mt0KE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "64b80bfb316b57cdb8919a9110ef63393d74382a",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-24.05",
+        "type": "indirect"
+      }
+    },
     "root": {
       "inputs": {
         "nixos2111": "nixos2111",
-        "nixos2211": "nixos2211"
+        "nixos2211": "nixos2211",
+        "nixos2405": "nixos2405"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -3,8 +3,9 @@
 
   inputs.nixos2111.url = "nixpkgs/nixos-21.11";
   inputs.nixos2211.url = "nixpkgs/nixos-22.11";
+  inputs.nixos2405.url = "nixpkgs/nixos-24.05";
 
-  outputs = { self, nixos2111, nixos2211 }:
+  outputs = { self, nixos2111, nixos2211, nixos2405 }:
     let
       platform = "x86_64-linux";
       packageName = year: "etaxes-ch-sg-${builtins.toString year}";
@@ -36,7 +37,7 @@
               __EOF__
 
               export HOME=`pwd`
-              export INSTALL4J_JAVA_HOME=${pkgs.jre8.home}
+              export INSTALL4J_JAVA_HOME=${pkgs.jre.home}
               export FONTCONFIG_FILE=${fontsConf}
               bash -ic './installer -q -varfile response.varfile'
 
@@ -92,6 +93,20 @@
           src = {
             url = defaultUrl 2022;
             sha256 = "sha256-BZfw/nmtl9+QJ2c2rtvq0fKnfLqR9rSxMUIsDD7JhLg=";
+          };
+        };
+        ${packageName 2023} = let year = 2023;
+        in mkETaxesFor {
+          pkgs = import nixos2405 {
+            system = platform;
+            config = mkAllowUnfreePkg year;
+          };
+          lib = nixos2405.lib;
+          inherit year;
+          version = "1.2.0";
+          src = {
+            url = defaultUrl 2023;
+            sha256 = "sha256-zNMmcPjjexnkc945cYZv2BH1ef/LLQ6hFt3kuz8nY+Y=";
           };
         };
 


### PR DESCRIPTION
- add 2023 version: 1.4.0, build number: 473
- switch to current JRE to avoid
  ```
  java.lang.UnsupportedClassVersionError: com/ifactory/launch/IFApplicationLauncher has been compiled by a more recent version of the Java Runtime (class file version 55.0), this version of the Java Runtime only recognizes class file versions up to 52.0
  	at java.lang.ClassLoader.defineClass1(Native Method)
  	at java.lang.ClassLoader.defineClass(ClassLoader.java:756)
  	at java.security.SecureClassLoader.defineClass(SecureClassLoader.java:142)
  	at java.net.URLClassLoader.defineClass(URLClassLoader.java:473)
  	at java.net.URLClassLoader.access$100(URLClassLoader.java:74)
  	at java.net.URLClassLoader$1.run(URLClassLoader.java:369)
  	at java.net.URLClassLoader$1.run(URLClassLoader.java:363)
  	at java.security.AccessController.doPrivileged(Native Method)
  	at java.net.URLClassLoader.findClass(URLClassLoader.java:362)
  	at java.lang.ClassLoader.loadClass(ClassLoader.java:418)
  	at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:352)
  	at java.lang.ClassLoader.loadClass(ClassLoader.java:351)
  	at com.exe4j.runtime.LauncherEngine.launch(LauncherEngine.java:80)
  	at com.install4j.runtime.launcher.UnixLauncher.start(UnixLauncher.java:69)
  	at install4j.com.ifactory.launch.IFApplicationLauncher.main(Unknown Source)
  ```